### PR TITLE
Add light and dark theme switching

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
       'error',
       'always'
     ],
+    'react/prop-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     'no-restricted-imports': [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,32 @@
 import React from 'react';
 import Home from './pages/Home';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import { ThemeProvider } from '@material-ui/core/styles';
 import { BrowserRouter } from 'react-router-dom';
 import { Route, Switch } from 'react-router-dom';
 import { JobPageRoute } from './pages/JobPage';
+import lightTheme from './themes/light';
+import darkTheme from './themes/dark';
+import useDarkMode from './themes/useDarkMode';
 
 const App = () => {
+
+  const { darkMode } = useDarkMode();
+
   return (
-    <BrowserRouter>
-      <CssBaseline />
-      <Switch>
-        <Route path="/job/:jobId">
-          <JobPageRoute />
-        </Route>
-        <Route>
-          <Home />
-        </Route>
-      </Switch>
-    </BrowserRouter>
+    <ThemeProvider theme={ darkMode ? darkTheme : lightTheme }>
+      <BrowserRouter>
+        <CssBaseline />
+        <Switch>
+          <Route path="/job/:jobId">
+            <JobPageRoute />
+          </Route>
+          <Route>
+            <Home />
+          </Route>
+        </Switch>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,8 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 // import MenuIcon from '@material-ui/icons/Menu';
 import PublishIcon from '@material-ui/icons/Publish';
+import Box from '@material-ui/core/Box';
+import ThemeSwitcher from './ThemeSwitcher';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -35,6 +37,9 @@ export default function ButtonAppBar() {
           >
             Publish Job Listing
           </Button>
+          <Box marginLeft={1}>
+           <ThemeSwitcher />
+          </Box>
         </Toolbar>
       </AppBar>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,7 +38,7 @@ export default function ButtonAppBar() {
             Publish Job Listing
           </Button>
           <Box marginLeft={1}>
-           <ThemeSwitcher />
+            <ThemeSwitcher />
           </Box>
         </Toolbar>
       </AppBar>

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import Brightness3Icon from '@material-ui/icons/Brightness3';
+import Brightness5Icon from '@material-ui/icons/Brightness5';
+
+import useDarkMode from '../themes/useDarkMode';
+
+export default function ThemeSwitcher() {
+
+  const { darkMode, toggle } = useDarkMode();
+
+  return (
+    <IconButton onClick={toggle} title={`Switch to ${ darkMode ? 'light' : 'dark'} mode`}>
+      {darkMode ? <Brightness3Icon/> : <Brightness5Icon/>}
+    </IconButton>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import DarkThemeProvider from './themes/DarkThemeProvider';
 
-ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(<DarkThemeProvider><App /></DarkThemeProvider>, document.getElementById('app'));

--- a/src/themes/DarkThemeContext.tsx
+++ b/src/themes/DarkThemeContext.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+
+type DarkThemeContextValue = {
+    darkMode: boolean,
+    toggle: () => void
+}
+
+const DarkThemeContext = React.createContext < DarkThemeContextValue > ({
+    darkMode: false,
+    toggle: () => {
+        return;
+    }
+});
+
+export default DarkThemeContext;

--- a/src/themes/DarkThemeContext.tsx
+++ b/src/themes/DarkThemeContext.tsx
@@ -7,10 +7,10 @@ type DarkThemeContextValue = {
 }
 
 const DarkThemeContext = React.createContext < DarkThemeContextValue > ({
-    darkMode: false,
-    toggle: () => {
-        return;
-    }
+  darkMode: false,
+  toggle: () => {
+    return;
+  }
 });
 
 export default DarkThemeContext;

--- a/src/themes/DarkThemeProvider.tsx
+++ b/src/themes/DarkThemeProvider.tsx
@@ -4,19 +4,19 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import DarkThemeContext from './DarkThemeContext';
 
 const DarkThemeProvider: React.FC = ({ children }) => {
-    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-    const [darkMode, setDarkMode] = React.useState(prefersDarkMode);
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const [darkMode, setDarkMode] = React.useState(prefersDarkMode);
 
-    useEffect(() => {
-        setDarkMode(prefersDarkMode);
-    }, [prefersDarkMode]);
+  useEffect(() => {
+    setDarkMode(prefersDarkMode);
+  }, [prefersDarkMode]);
 
-    const value = React.useMemo(() => ({
-        darkMode,
-        toggle: () => setDarkMode((mode) => !mode),
-    }), [darkMode]);
+  const value = React.useMemo(() => ({
+    darkMode,
+    toggle: () => setDarkMode((mode) => !mode),
+  }), [darkMode]);
 
-    return <DarkThemeContext.Provider value={value}>{children}</DarkThemeContext.Provider>;
+  return <DarkThemeContext.Provider value={value}>{children}</DarkThemeContext.Provider>;
 };
 
 

--- a/src/themes/DarkThemeProvider.tsx
+++ b/src/themes/DarkThemeProvider.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+
+import DarkThemeContext from './DarkThemeContext';
+
+const DarkThemeProvider: React.FC = ({ children }) => {
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    const [darkMode, setDarkMode] = React.useState(prefersDarkMode);
+
+    useEffect(() => {
+        setDarkMode(prefersDarkMode);
+    }, [prefersDarkMode]);
+
+    const value = React.useMemo(() => ({
+        darkMode,
+        toggle: () => setDarkMode((mode) => !mode),
+    }), [darkMode]);
+
+    return <DarkThemeContext.Provider value={value}>{children}</DarkThemeContext.Provider>;
+};
+
+
+export default DarkThemeProvider;

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -1,0 +1,7 @@
+import createMuiTheme  from '@material-ui/core/styles/createMuiTheme';
+
+export default createMuiTheme({
+  palette: {
+    type: 'dark',
+  },
+});

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -1,0 +1,7 @@
+import createMuiTheme  from '@material-ui/core/styles/createMuiTheme';
+
+export default createMuiTheme({
+  palette: {
+    type: 'light',
+  },
+});

--- a/src/themes/useDarkMode.tsx
+++ b/src/themes/useDarkMode.tsx
@@ -1,0 +1,13 @@
+import {useContext } from 'react';
+
+
+import DarkThemeContext from './DarkThemeContext';
+
+
+const useDarkMode = () => {
+  const {darkMode, toggle} = useContext(DarkThemeContext);
+
+  return {darkMode, toggle};
+};
+
+export default useDarkMode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,6 +1037,13 @@ binary-extensions@^1.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz"
@@ -2145,6 +2152,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3416,6 +3428,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+nan@^2.12.1:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanoid@^3.1.22:
   version "3.1.22"


### PR DESCRIPTION
This PR adds support for a light and dark theme as well as a  component to toggle the current theme. The actual implementation of the themes (in terms of colours etc.) is left to a later stage. For the time being, we rely on material-ui's light and dark palettes. 

<img width="1440" alt="Screen Shot 2021-04-12 at 11 20 57 PM" src="https://user-images.githubusercontent.com/717143/114464268-d21f1300-9be5-11eb-8460-171f4fdcb0a1.png">

<img width="1440" alt="Screen Shot 2021-04-12 at 11 21 50 PM" src="https://user-images.githubusercontent.com/717143/114464311-e105c580-9be5-11eb-9719-1e8abdcda58c.png">
