### PR TITLE
Add HTML sanitizer and markdown parser

### DIFF
--- a/mocks/jobs.json
+++ b/mocks/jobs.json
@@ -39,7 +39,7 @@
       "timestamp": "2021-04-09T23:41:23.668Z",
       "source": "Jobs R' Us",
       "header": "Software Enginer (w/m/d)",
-      "content": "Looking for a great software engineer. Are you a javascript rockstar? Does python tingle your jingle? They you're the right one for the job!<br>This content might contain some HTML",
+      "content": "Looking for a great software engineer. Are you a javascript rockstar? Does python tingle your jingle? They you're the right one for the job!<br>This content might contain some *Markdown* <- Keep this for testing purposes",
       "language": "de",
       "experience": "senior",
       "employment_time": "full time",

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,15 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@types/dompurify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.1.tgz",
+      "integrity": "sha512-3JwbEeRVQ3n6+JgBW/hCdkydRk9/vWT+UEglcXEJqLJEcUganDH37zlfLznxPKTZZfDqA9K229l1qN458ubcOQ==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
@@ -627,6 +636,12 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "@types/trusted-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.0.tgz",
+      "integrity": "sha512-I8MnZqNXsOLHsU111oHbn3khtvKMi5Bn4qVFsIWSJcCP1KKDiXX5AEw8UPk0nSopeC+Hvxt6yAy1/a5PailFqg==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.21.0",
@@ -3282,6 +3297,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
+      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -7875,6 +7895,11 @@
           }
         }
       }
+    },
+    "snarkdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-2.0.0.tgz",
+      "integrity": "sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A=="
     },
     "sockjs": {
       "version": "0.3.21",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "^7.13.13",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^13.1.5",
+    "@types/dompurify": "^2.2.1",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
     "@types/react-router": "^5.1.13",
@@ -61,9 +62,11 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "dompurify": "^2.2.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router": "^5.2.0",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "snarkdown": "^2.0.0"
   }
 }

--- a/src/__tests__/e2e.test.jsx
+++ b/src/__tests__/e2e.test.jsx
@@ -20,4 +20,10 @@ describe('Test Suite', () => {
     expect(jobs.length).toEqual(jobsData.jobs.length);
 
   });
+
+  it('renders markdown', async () => {
+    const { findByText } = render(<App />);
+    const markdown = await findByText('Markdown');
+    expect(markdown.nodeName).toEqual('EM');
+  });
 });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,6 +5,7 @@ import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import Sanitize from './Sanitize';
 
 const useStyles = makeStyles({
   root: {
@@ -38,7 +39,7 @@ const SimpleCard = ({
         )}
         {description && (
           <Typography variant="body2" color="textSecondary" component="p">
-            {description}
+            <Sanitize inline htmlOrMarkdown={description} />
           </Typography>
         )}
         {children}

--- a/src/components/Sanitize.tsx
+++ b/src/components/Sanitize.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import dompurify from 'dompurify';
+import snarkdown from 'snarkdown';
+
+/**
+ * Sanitize a string of HTML with dompurify - output ready to input to dangerouslySetInnerHTML
+ */
+const purify = (dirty: string) => ({
+  __html: dompurify.sanitize(dirty, {USE_PROFILES: {html: true}})
+});
+
+/**
+ * Sanitize and render a string of HTML or markdown (markdown will be parsed)
+ *
+ * @param param0.htmlOrMarkdown - A string of markdown or html to render 
+ * @param param0.inline - Return an inline element
+ */
+const Sanitize = ({ htmlOrMarkdown, inline }: {htmlOrMarkdown: string, inline?: boolean}) => {
+  const innerHTML = purify(snarkdown(htmlOrMarkdown));
+
+  if (inline) {
+    return <span dangerouslySetInnerHTML={innerHTML} />;
+  } else {
+    return <div dangerouslySetInnerHTML={innerHTML} />;
+  }
+};
+
+export default Sanitize;

--- a/src/pages/JobPage.tsx
+++ b/src/pages/JobPage.tsx
@@ -13,6 +13,7 @@ import { useFetchJob } from '../api/useFetch';
 import FetchWrapper from '../components/FetchWrapper';
 import PageLayout from '../layouts/PageLayout';
 import { IJob } from '../types';
+import Sanitize from '../components/Sanitize';
 
 interface Props {
   jobId: string;
@@ -59,11 +60,8 @@ function JobPage({ jobId }: Props): ReactElement {
                   }
                 />
                 <CardContent>
-                  {/* you could use the library react-html-parser too but: its
-                  pretty outdated (needs polyfills and different react version /
-                  -force flag)*/}
                   {data.content && (
-                    <div dangerouslySetInnerHTML={{ __html: data.content }} />
+                    <Sanitize htmlOrMarkdown={data.content} />
                   )}
                 </CardContent>
               </Card>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/dompurify@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.2.1.tgz#eebf3af8afe2f577a53acab9d98a3a4cb04bbbe7"
+  integrity sha512-3JwbEeRVQ3n6+JgBW/hCdkydRk9/vWT+UEglcXEJqLJEcUganDH37zlfLznxPKTZZfDqA9K229l1qN458ubcOQ==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz"
@@ -1507,6 +1514,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/trusted-types@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.0.tgz#aee6e868fcef74f2b8c71614b6df81a601a42f17"
+  integrity sha512-I8MnZqNXsOLHsU111oHbn3khtvKMi5Bn4qVFsIWSJcCP1KKDiXX5AEw8UPk0nSopeC+Hvxt6yAy1/a5PailFqg==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -3418,6 +3430,11 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+dompurify@^2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.2.8.tgz#ce88e395f6d00b6dc53f80d6b2a6fdf5446873c6"
+  integrity sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww==
 
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
@@ -8069,6 +8086,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+snarkdown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-2.0.0.tgz#b1feb4db91b9f94a8ebbd7a50f3e99aee18b1e03"
+  integrity sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==
 
 sockjs-client@^1.5.0:
   version "1.5.1"


### PR DESCRIPTION
- Added a Sanitize component to sanitize, parse, and render any string of html or markdown
- Implemented it to render the `description` in Card and JobPage
- Addresses #13 
- Added test (tests the markdown rendering)

I went with `dompurify` for XSS sanitizing and `snarkdown` for super lightweight markdown parsing. Overall, it adds ~7kB to the gzipped build, 6kB from `dompurify` and 1kB from `snarkdown`. Not ideal but these are the smallest packages I could find (both are actively developed and widely compatible)